### PR TITLE
Add d3d8 DLL override for Wine

### DIFF
--- a/setup.iss
+++ b/setup.iss
@@ -9,13 +9,13 @@
 #define MyAppExeName "Freelancer.exe"
 #define MyFolderName "freelancer-hd-edition-" + MyAppVersion
 #define MyZipName "freelancerhd"
-; This variable controls whether the zip is shipped with the exe or downloaded from a mirror 
+; This variable controls whether the zip is shipped with the exe or downloaded from a mirror
 #define AllInOneInstall true
 ; TODO: Remember to change the mirror locations for each release
 #dim Mirrors[1] {"https://github.com/BC46/freelancer-hd-edition/archive/refs/tags/" + MyAppVersion + ".zip"}
 ; TODO: Update sizes for each release
-#define SizeZip 2438619136 
-#define SizeExtracted 4195188736 
+#define SizeZip 2438619136
+#define SizeExtracted 4195188736
 #define SizeVanilla 985624576
 #define SizeBuffer 50000
 #define SizeAll SizeZip + SizeExtracted + SizeVanilla + SizeBuffer
@@ -59,7 +59,7 @@ Name: "{commondesktop}\Freelancer HD Edition"; Filename: "{app}\EXE\{#MyAppExeNa
 
 [Files]
 Source: "Assets\Text\installinfo.txt"; DestDir: "{app}"; Flags: ignoreversion deleteafterinstall
-Source: "Assets\Text\PerfOptions.ini"; DestDir: "{app}"; Flags: ignoreversion deleteafterinstall 
+Source: "Assets\Text\PerfOptions.ini"; DestDir: "{app}"; Flags: ignoreversion deleteafterinstall
 Source: "Assets\Fonts\AGENCYB.TTF"; DestDir: "{autofonts}"; FontInstall: "Agency FB Bold"; Flags: onlyifdoesntexist uninsneveruninstall
 Source: "Assets\Fonts\AGENCYR.TTF"; DestDir: "{autofonts}"; FontInstall: "Agency FB"; Flags: onlyifdoesntexist uninsneveruninstall
 Source: "Assets\Fonts\ARIALUNI.TTF"; DestDir: "{autofonts}"; FontInstall: "Arial Unicode MS"; Flags: onlyifdoesntexist uninsneveruninstall
@@ -106,7 +106,7 @@ begin
     if CurStep = ssPostInstall then
     begin
         # if !AllInOneInstall
-          if (OfflineInstall <> 'false') then 
+          if (OfflineInstall <> 'false') then
             FileCopy(OfflineInstall,ExpandConstant('{tmp}\freelancerhd.7z'),false);
         # endif
 
@@ -128,7 +128,7 @@ begin
         WizardForm.StatusLabel.Caption := ExpandConstant('Moving {#MyAppName}');
 
         DirectoryCopy(ExpandConstant('{app}\{#MyFolderName}'),ExpandConstant('{app}'),True);
-        
+
         DelTree(ExpandConstant('{app}\{#MyFolderName}'), True, True, True);
         UpdateProgress(90);
 
@@ -150,7 +150,7 @@ begin
         Process_Planetscape();
         Process_Win10();
         Process_HUD();
-        Process_DarkHUD(); 
+        Process_DarkHUD();
         Process_FlatIcons();
         Process_WeaponGroups(); // Must be called after Process_HUD();
         Process_DxWrapper();
@@ -163,7 +163,7 @@ begin
         UpdateProgress(95);
 
         // Perform operations that (potentially) do not work on Wine
-        if not IsWine then 
+        if not IsWine then
         begin
           // Delete potential UTF-8 BOM headers in all edited ini files
           RemoveBOM(ExpandConstant('{app}\EXE\dacom.ini'));
@@ -175,6 +175,10 @@ begin
           RemoveBOM(ExpandConstant('{app}\EXE\newplayer.fl'));
           RemoveBOM(ExpandConstant('{app}\EXE\dxwrapper.ini'));
           RemoveBOM(ExpandConstant('{app}\EXE\ReShadePreset.ini'));
+        end else
+        begin
+          // Write d3d8 DLL override for Wine/Linux. For more information, see https://wiki.winehq.org/Wine_User%27s_Guide#DLL_Overrides
+          RegWriteStringValue(HKEY_CURRENT_USER, 'Software\Wine\DllOverrides', 'd3d8', 'native,builtin');
         end;
 
         // Delete restart.fl to stop crashes
@@ -269,7 +273,7 @@ begin
             SuppressibleMsgBox('All downloads failed. Please contact us on Discord: https://discord.gg/ScqgYuFqmU', mbError, MB_OK, IDOK)
           else
             if SuppressibleMsgBox('Download failed. Do you want to try downloading with an alternate mirror?', mbError, MB_RETRYCANCEL, IDRETRY) = IDCANCEL then
-              i := mirrors.Count - 1; 
+              i := mirrors.Count - 1;
           Result := False;
           DownloadPage.Hide;
         finally
@@ -289,7 +293,7 @@ begin
 
       // Copy mirrors from our preprocessor to our string array. This allows us to define the array at the top of the file for easy editing
       mirrors := TStringList.Create;
-   
+
       #sub PopMirrors
         mirrors.add('{#Mirrors[i]}');
       #endsub


### PR DESCRIPTION
This adds a registry write when the installer is ran on Linux in Wine. If Wine is detected, it will write the DLL override needed for HD Edition to work 'out of the box' on Linux, without needing the user to override it manually in the Wine prefix they are using. This will bypass the Lutris approval issue, and also make it work for all other 'Wine managers'.